### PR TITLE
Filter out conditions with undefined values

### DIFF
--- a/instance/conditions.js
+++ b/instance/conditions.js
@@ -5,6 +5,8 @@ module.exports = {
         }
         var sql = [];
         for (var field in conditions) {
+            if (typeof conditions[field] === 'undefined') { continue; }
+
             if (description[field]) {
                 var value = description[field](conditions[field], params);
                 if (value != null && value != undefined) {

--- a/test/instance/conditions.js
+++ b/test/instance/conditions.js
@@ -25,12 +25,20 @@ describe('Conditions', function() {
         assert.deepEqual(params, [ 1 ]);
     });
 
-    it('where with empty condition', function() {
+    it('where with null condition', function() {
         var params = [ 1 ];
         var where = conditions.where(description, { id : null, name : 'Weyland-Yutani Corporation', empty : 123 }, params);
 
         assert.equal(where, ' WHERE "id"=$2 AND "name"=$3', 'See valid where');
         assert.deepEqual(params, [ 1, null, 'Weyland-Yutani Corporation' ]);
+    });
+
+    it('where with undefined condition', function() {
+        var params = [ 1 ];
+        var where = conditions.where(description, { id : undefined, name : 'Weyland-Yutani Corporation', empty : 123 }, params);
+
+        assert.equal(where, ' WHERE "name"=$2', 'See valid where');
+        assert.deepEqual(params, [ 1, 'Weyland-Yutani Corporation' ]);
     });
 
     it('where without conditions', function() {


### PR DESCRIPTION
Filter out conditions with undefined values before pushing them into params array.

This PR adds a check for condition's value in addition to the check for resulting condition's SQL and makes it possible to skip conditions with undefined values for columns from a model (i.e. existing in a table). Also we will be able to skip such conditions without the need to manually return undefined or null from custom conditions functions.

`null` is a ‘legal’ value though so we don't skip conditions with it.